### PR TITLE
fix(): dependency update of node-sass to fix npm install breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "html-webpack-plugin": "^3.2.0",
     "jquery": "^3.3.1",
     "mini-css-extract-plugin": "^0.5.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.13.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "popper.js": "^1.14.7",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
node-sass@4.11.0 breaks npm install on Windows 10, resulting in the following error

```
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at PythonFinder.failNoPython (C:\Users\samir\Desktop\woooha\webpack-demo-app\node_modules\node-gyp\lib\configure.js:484:19)
gyp ERR! stack     at PythonFinder.<anonymous> (C:\Users\samir\Desktop\woooha\webpack-demo-app\node_modules\node-gyp\lib\configure.js:509:16)
gyp ERR! stack     at C:\Users\samir\Desktop\woooha\webpack-demo-app\node_modules\graceful-fs\polyfills.js:282:31
gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:158:21)
gyp ERR! System Windows_NT 10.0.18363
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\samir\\Desktop\\woooha\\webpack-demo-app\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd C:\Users\samir\Desktop\woooha\webpack-demo-app\node_modules\node-sass
gyp ERR! node -v v12.13.1
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
Build failed with error code: 1
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@4.11.0 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@4.11.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

updating node-sass to version 4.13.1 solves this problem.


EDIT: **great tutorial btw, love your content! keep it up** 😄 