### PR TITLE
CleanWebpackPlugin not a constructor

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const common = require("./webpack.common");
 const merge = require("webpack-merge");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");


### PR DESCRIPTION
This is currently a bug uptil the 10th commit.
Using "clean-webpack-plugin": "^3.0.0", the syntax for import `clean-webpack-plugin` has changed from
```
const CleanWebpackPlugin = require("clean-webpack-plugin");
```
to 
```
const { CleanWebpackPlugin } = require("clean-webpack-plugin");
```

Steps to recreate are,
```
npm install --save-dev clean-webpack-plugin
npm run build
```

The complete error thrown is,
```
> webpack --config webpack.prod.js

/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/cli.js:93
                                throw err;
                                ^

TypeError: CleanWebpackPlugin is not a constructor
    at Object.<anonymous> (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/webpack.prod.js:12:15)
    at Module._compile (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Module.require (internal/modules/cjs/loader.js:1089:19)
    at require (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
    at WEBPACK_OPTIONS (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/utils/convert-argv.js:114:13)
    at requireConfig (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/utils/convert-argv.js:116:6)
    at /home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/utils/convert-argv.js:123:17
    at Array.forEach (<anonymous>)
    at module.exports (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/utils/convert-argv.js:121:15)
    at /home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/cli.js:71:45
    at Object.parse (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/yargs/yargs.js:567:18)
    at /home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/cli.js:49:8
    at Object.<anonymous> (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack-cli/bin/cli.js:366:3)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Module.require (internal/modules/cjs/loader.js:1089:19)
    at require (internal/modules/cjs/helpers.js:73:18)
    at Object.<anonymous> (/home/saif/Desktop/Folders/Software/Webpack/webpack-demo/node_modules/webpack/bin/webpack.js:156:2)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! webpack-demo@1.0.0 build: `webpack --config webpack.prod.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the webpack-demo@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```